### PR TITLE
fix: show autocomplete hints above other windows

### DIFF
--- a/addon/hint/show-hint.css
+++ b/addon/hint/show-hint.css
@@ -1,6 +1,6 @@
 .CodeMirror-hints {
   position: absolute;
-  z-index: 10;
+  z-index: 1000;
   overflow: hidden;
   list-style: none;
 


### PR DESCRIPTION
This is required for hints to be visible which is needed for !cswendrowski/FoundryVTT-Custom-CSS/pull/11